### PR TITLE
Ignore blank lines preceding actual code input in E mode.

### DIFF
--- a/bf.pl
+++ b/bf.pl
@@ -17,7 +17,8 @@ sub getkey {
 sub getline {
 	ReadMode 0;
 	my $line;
-	while (not defined ($line = ReadLine(0))) { }
+	# Blank lines preceding actual code input will be ignored
+	until ( ($line = ReadLine(0) ) && $line =~ /\S/) { }
 	chomp $line;
 	return $line;
 }
@@ -89,8 +90,6 @@ while ($key ne 'Q' and $key ne 'q') {
 	$key = getkey();
 
 	if ($key eq 'E' or $key eq 'e') {
-		# TODO: Allow line breaks
-		#       Maybe accept input after 1 or 2 blank lines
 		print "Please enter your code: \n";
 		my $line = getline();
 		my $result = execute($line);

--- a/bf.pl
+++ b/bf.pl
@@ -90,6 +90,7 @@ while ($key ne 'Q' and $key ne 'q') {
 	$key = getkey();
 
 	if ($key eq 'E' or $key eq 'e') {
+		# TODO: Allow line breaks
 		print "Please enter your code: \n";
 		my $line = getline();
 		my $result = execute($line);


### PR DESCRIPTION
This pull request attempts to fix #1 and the associated TODO comment. Hopefully it's the behaviour you had in mind?